### PR TITLE
Added function to create the link names for Python and Python config.

### DIFF
--- a/src/version_manager/python_version_manager.rs
+++ b/src/version_manager/python_version_manager.rs
@@ -119,6 +119,7 @@ impl PythonVersionManager {
         self.configure_python(&python_source_dir, install_dir, verbose)?;
         self.compile_python(&python_source_dir, verbose)?;
         self.install_python(&python_source_dir, verbose)?;
+        self.link_names_python(&install_dir, verbose)?;
 
         shuru::log!("Python {} built and installed successfully.", self.version);
         Ok(())
@@ -158,6 +159,31 @@ impl PythonVersionManager {
         make_install_cmd.arg("install").current_dir(source_dir);
 
         PythonVersionManager::run_command(&mut make_install_cmd, verbose)?;
+        Ok(())
+    }
+
+    fn link_names_python(&self, install_dir: &std::path::Path, verbose: bool) -> Result<(), Error> {
+        shuru::log!("Creating link names for Python...");
+        let binary_dir = format!("{}/bin", install_dir.to_string_lossy());
+
+        let mut link_name_python_cmd = Command::new("ln");
+        link_name_python_cmd
+            .arg("-s")
+            .arg("python3")
+            .arg("python")
+            .current_dir(&binary_dir);
+
+        PythonVersionManager::run_command(&mut link_name_python_cmd, verbose)?;
+
+        let mut link_name_python_config_cmd = Command::new("ln");
+        link_name_python_config_cmd
+            .arg("-s")
+            .arg("python3-config")
+            .arg("python-config")
+            .current_dir(binary_dir);
+
+        PythonVersionManager::run_command(&mut link_name_python_config_cmd, verbose)?;
+
         Ok(())
     }
 


### PR DESCRIPTION
# BUG FIX

## Description

It resolves the bug found in the issue: https://github.com/shuru-project/shuru/issues/15.

## The problem

The problem was that Python users are usually used to typing the command “python”. When doing this with Shuru, it does not find this command in the custom installation because it does not automatically create the linked names for **“python” and “python-config”**. Instead, the Python installation generates a file called “python3”.

As you can see in my local directory, the “python” command has several links, including one for “python” that links to the “python3” one.

```text
$ ls -lha /usr/bin/python*
lrwxrwxrwx 1 root root    7 Sep  8 07:18 /usr/bin/python -> python3
lrwxrwxrwx 1 root root   10 Sep  8 07:18 /usr/bin/python3 -> python3.12
-rwxr-xr-x 1 root root  15K Sep  8 07:18 /usr/bin/python3.12
-rwxr-xr-x 1 root root 3.3K Sep  8 07:18 /usr/bin/python3.12-config
lrwxrwxrwx 1 root root   17 Sep  8 07:18 /usr/bin/python3-config -> python3.12-config
lrwxrwxrwx 1 root root   14 Sep  8 07:18 /usr/bin/python-config -> python3-config
```

As shown in the Shuru directory after installing Python, it does not contain the links mentioned above.

```text
~/.shuru/python/3.10.2/install/bin
$ ls -lha .
total 17M
lrwxrwxrwx 1 wolf users   10 Oct  7 14:49 python3 -> python3.10
-rwxr-xr-x 1 wolf users  17M Oct  7 14:49 python3.10
-rwxr-xr-x 1 wolf users 3.1K Oct  7 14:49 python3.10-config
lrwxrwxrwx 1 wolf users   17 Oct  7 14:49 python3-config -> python3.10-config
```

### Expected output

The expected output is the Python version 3.10.2 and the Python path showing the Shuru installation. It is achieved with this fix.

```bash
./shuru version
Python 3.10.2

$ ./shuru whereis
python: /usr/bin/python /home/wolf/.shuru/python/3.10.2/install/bin/python /usr/share/man/man1/python.1.gz
```

The linked names of Python are done.

```text
~/.shuru/python/3.10.2/install/bin
$ ls -lha .
total 17M
lrwxrwxrwx 1 wolf users    7 Oct  7 14:50 python -> python3
lrwxrwxrwx 1 wolf users   10 Oct  7 14:49 python3 -> python3.10
-rwxr-xr-x 1 wolf users  17M Oct  7 14:49 python3.10
-rwxr-xr-x 1 wolf users 3.1K Oct  7 14:49 python3.10-config
lrwxrwxrwx 1 wolf users   17 Oct  7 14:49 python3-config -> python3.10-config
lrwxrwxrwx 1 wolf users   14 Oct  7 14:50 python-config -> python3-config
```