### PR TITLE
feat: add `source` to `VersionManagerError` errors

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -17,8 +17,12 @@ pub enum VersionManagerError {
     #[error("Unable to find home directory")]
     UnableHomeDirectory {},
 
-    #[error("Failed to download version from '{url}' | {error}")]
-    DownloadError { url: String, error: reqwest::Error },
+    #[error("Failed to download version from '{url}' | {source}")]
+    DownloadError {
+        url: String,
+        #[source]
+        source: reqwest::Error,
+    },
 
     #[error("Failed to download {package} from '{url}' | Status: {status}")]
     FailedDownloadPackage {
@@ -27,14 +31,26 @@ pub enum VersionManagerError {
         status: String,
     },
 
-    #[error("Failed to create download file '{file}' | {error}")]
-    FailedCreateFile { file: String, error: std::io::Error },
+    #[error("Failed to create download file '{file}' | {source}")]
+    FailedCreateFile {
+        file: String,
+        #[source]
+        source: std::io::Error,
+    },
 
-    #[error("Failed to write a compressed file '{file}' | {error}")]
-    FailedWriteFile { file: String, error: reqwest::Error },
+    #[error("Failed to write a compressed file '{file}' | {source}")]
+    FailedWriteFile {
+        file: String,
+        #[source]
+        source: reqwest::Error,
+    },
 
-    #[error("Failed to remove downloaded archive '{file}' | {error}")]
-    FailedDeleteFile { file: String, error: std::io::Error },
+    #[error("Failed to remove downloaded archive '{file}' | {source}")]
+    FailedDeleteFile {
+        file: String,
+        #[source]
+        source: std::io::Error,
+    },
 
     #[error("Failed to extract archive '{file}' to '{target}' | {error}")]
     FailedExtractArchive {
@@ -43,10 +59,11 @@ pub enum VersionManagerError {
         error: String,
     },
 
-    #[error("Failed to run command '{command}' | {error}")]
+    #[error("Failed to run command '{command}' | {source}")]
     FailedRunCommand {
         command: String,
-        error: std::io::Error,
+        #[source]
+        source: std::io::Error,
     },
 
     #[error("{package} build command failed | Exit code: {status}{error}")]

--- a/src/version_manager/node_version_manager.rs
+++ b/src/version_manager/node_version_manager.rs
@@ -99,7 +99,7 @@ impl NodeVersionManager {
 
         let mut response = match reqwest::blocking::get(&url) {
             Ok(response) => response,
-            Err(error) => return Err(VersionManagerError::DownloadError { url, error }),
+            Err(source) => return Err(VersionManagerError::DownloadError { url, source }),
         };
 
         if !response.status().is_success() {
@@ -112,19 +112,19 @@ impl NodeVersionManager {
 
         let mut file = match std::fs::File::create(download_file_path) {
             Ok(file) => file,
-            Err(error) => {
+            Err(source) => {
                 return Err(VersionManagerError::FailedCreateFile {
                     file: download_file_path.to_string_lossy().to_string(),
-                    error,
+                    source,
                 })
             }
         };
 
         response
             .copy_to(&mut file)
-            .map_err(|error| VersionManagerError::FailedWriteFile {
+            .map_err(|source| VersionManagerError::FailedWriteFile {
                 file: download_file_path.to_string_lossy().to_string(),
-                error,
+                source,
             })?;
 
         shuru::log!("Download complete.");
@@ -151,10 +151,10 @@ impl NodeVersionManager {
         download_file_path: &std::path::Path,
     ) -> Result<(), VersionManagerError> {
         shuru::log!("Cleaning up the downloaded archive...");
-        std::fs::remove_file(download_file_path).map_err(|error| {
+        std::fs::remove_file(download_file_path).map_err(|source| {
             VersionManagerError::FailedDeleteFile {
                 file: download_file_path.to_string_lossy().to_string(),
-                error,
+                source,
             }
         })
     }


### PR DESCRIPTION
Closes #31 

This patch adds `source` to `VersionManagerErrors`, except in the case where the error source is a String. Please let me know if I've missed anything and I'll gladly push a fix. 

I can also take a look at issue 30 if you'd like, it also seems pretty straightforward - however I didn't want to link the issue so that this PR won't close it.