### PR TITLE
feat: add task dependency feature to command runner

### DIFF
--- a/examples/dependent-node-tasks/shuru.toml
+++ b/examples/dependent-node-tasks/shuru.toml
@@ -1,0 +1,18 @@
+[tasks.clean]
+command = "rm -rf build/*"
+description = "Clean up previous build artifacts."
+
+[tasks.build]
+depends = ["clean"]
+command = "npm install && npm run build"
+description = "Install dependencies and build the application."
+
+[tasks.test]
+depends = ["build"]
+command = "npm test"
+description = "Run tests to ensure application quality."
+
+[tasks.deploy]
+depends = ["test"]
+command = "npm run deploy"
+description = "Deploy the application to production."

--- a/src/command_runner.rs
+++ b/src/command_runner.rs
@@ -31,6 +31,10 @@ impl CommandRunner {
     pub fn run_command(&self, name: &str) -> Result<ExitStatus, Error> {
         let task = self.find_task(name)?;
 
+        for dep in &task.depends {
+            self.run_command(dep)?;
+        }
+
         let current_dir = std::env::current_dir().map_err(|e| {
             Error::CommandExecutionError(format!("Failed to get current directory: {}", e))
         })?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,6 +11,11 @@ pub struct TaskConfig {
     pub command: String,
     pub dir: Option<String>,
     pub default: Option<bool>,
+    #[serde(default)]
+    pub depends: Vec<String>,
+    // TODO: add a command to show list of commands with description
+    #[serde(default)]
+    pub description: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -51,6 +56,11 @@ impl Config {
     pub fn validate_tasks(&self) -> Result<(), Error> {
         for (task_name, task_config) in &self.tasks {
             task_config.validate(task_name)?;
+            for dep in &task_config.depends {
+                if !self.tasks.contains_key(dep) {
+                    return Err(Error::CommandNotFound(dep.to_string()));
+                }
+            }
         }
         Ok(())
     }


### PR DESCRIPTION
This PR adds support for task dependencies in the task runner. Tasks can now specify dependencies, ensuring they execute in the correct order.

### Key Changes
- **TaskConfig Update**: Introduced a `depends` field to specify task dependencies.
- **Validation**: Ensured all dependencies are valid during configuration parsing.
- **Execution Logic**: Updated `run_command` to run dependencies before the main task.

### Example

```toml
[tasks.a]
command = "echo 'Task A running'"

[tasks.b]
depends = ["a"]
command = "echo 'Task B running after A'"
```

Now, executing task `b` will run task `a` first.