### PR TITLE
feat: add task env feature

### DIFF
--- a/examples/task-env/shuru.toml
+++ b/examples/task-env/shuru.toml
@@ -1,0 +1,3 @@
+[tasks.greet]
+command = "echo \"Hello, $USER_NAME! You are in the $ENVIRONMENT environment.\""
+env = { USER_NAME = "Alice", ENVIRONMENT = "development" }

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,9 +13,10 @@ pub struct TaskConfig {
     pub default: Option<bool>,
     #[serde(default)]
     pub depends: Vec<String>,
-    // TODO: add a command to show list of commands with description
     #[serde(default)]
     pub description: Option<String>,
+    #[serde(default)]
+    pub env: HashMap<String, String>,
 }
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
This PR introduces the capability to define environment variables for tasks within the configuration file.

### Key changes
- **Environment Variables**: Each task can now specify a set of environment variables that will be available during command execution. For example, the greet task utilizes `USER_NAME` and `ENVIRONMENT` variables to produce a personalized greeting.