### PR TITLE
feat: detect and load versions from .python-version and .nvmrc files

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,10 @@
 use clap::Parser;
-use shuru::{commands, config::Config, error::Error, tools::task_runner::TaskRunner};
+use shuru::{
+    commands,
+    config::Config,
+    error::Error,
+    tools::{task_runner::TaskRunner, version_manager::compat::update_versions_from_files},
+};
 
 #[derive(Parser)]
 #[clap(version, about = "Shuru task runner", long_about = None)]
@@ -31,8 +36,10 @@ fn load_config() -> Result<Config, Error> {
         _ => Error::ConfigLoadError(format!("Unable to read config file: {}", e)),
     })?;
 
-    let config: Config = toml::from_str(&config_str)
+    let mut config: Config = toml::from_str(&config_str)
         .map_err(|e| Error::ConfigLoadError(format!("Invalid config file format: {}", e)))?;
+
+    update_versions_from_files(&mut config);
 
     config.validate_tasks()?;
 

--- a/src/tools/version_manager/compat.rs
+++ b/src/tools/version_manager/compat.rs
@@ -1,0 +1,53 @@
+use shuru::{
+    config::Config,
+    tools::version_manager::{VersionInfo, VersionedCommand},
+};
+
+fn get_nvmrc_version() -> Option<VersionInfo> {
+    if let Ok(version_str) = std::fs::read_to_string(".nvmrc") {
+        let version = version_str.trim();
+        if version.is_empty() {
+            return None;
+        }
+
+        // Ensure version starts with 'v' as per the requirement
+        let version = if version.starts_with('v') {
+            version.to_string()
+        } else {
+            format!("v{}", version)
+        };
+
+        Some(VersionInfo::Simple(version))
+    } else {
+        None
+    }
+}
+
+fn get_python_version() -> Option<VersionInfo> {
+    if let Ok(version_str) = std::fs::read_to_string(".python-version") {
+        let version = version_str.trim();
+        if version.is_empty() {
+            return None;
+        }
+
+        Some(VersionInfo::Simple(version.to_string()))
+    } else {
+        None
+    }
+}
+
+pub fn update_versions_from_files(config: &mut Config) {
+    if let Some(node_version) = get_nvmrc_version() {
+        shuru::log!("Detected Node.js version from .nvmrc: {}. You can add this to shuru.toml under [versions] as `node = \"{}\"`", node_version.get_version(), node_version.get_version());
+
+        config.versions.insert(VersionedCommand::Node, node_version);
+    }
+
+    if let Some(python_version) = get_python_version() {
+        shuru::log!("Detected Python version from .python-version: {}. You can add this to shuru.toml under [versions] as `python = \"{}\"`", python_version.get_version(), python_version.get_version());
+
+        config
+            .versions
+            .insert(VersionedCommand::Python, python_version);
+    }
+}

--- a/src/tools/version_manager/mod.rs
+++ b/src/tools/version_manager/mod.rs
@@ -13,6 +13,8 @@ pub use python_version_manager::PythonVersionManager;
 mod versioned_command;
 pub use versioned_command::{deserialize_versions, VersionInfo, VersionedCommand};
 
+pub mod compat;
+
 pub trait VersionManager {
     fn install_and_get_binary_path(&self) -> Result<std::path::PathBuf, Error>;
 }


### PR DESCRIPTION
Added functionality to automatically detect Node.js and Python versions from `.nvmrc` and `.python-version` files. If these files are present, the detected versions are logged and automatically added to the `versions` section of the configuration (but are not automatically written to the `shuru.toml` file). Users are informed about the detected versions and prompted to add them to `shuru.toml` if desired.