### PR TITLE
feat: task suggestion logic for fuzzy matching using simsearch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,7 +151,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim",
+ "strsim 0.11.1",
 ]
 
 [[package]]
@@ -1003,10 +1003,21 @@ dependencies = [
  "flate2",
  "reqwest",
  "serde",
+ "simsearch",
  "strum",
  "tar",
  "thiserror",
  "toml",
+]
+
+[[package]]
+name = "simsearch"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c869b25830e4824ef7279015cfc298a0674aca6a54eeff2efce8d12bf3701fe"
+dependencies = [
+ "strsim 0.10.0",
+ "triple_accel",
 ]
 
 [[package]]
@@ -1039,6 +1050,12 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strsim"
@@ -1256,6 +1273,12 @@ checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
 ]
+
+[[package]]
+name = "triple_accel"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622b09ce2fe2df4618636fb92176d205662f59803f39e70d1c333393082de96c"
 
 [[package]]
 name = "try-lock"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ dirs = "5.0"
 tar = "0.4"
 flate2 = "1.0"
 strum = { version = "0.26", features = ["derive"] }
-
+simsearch = "0.2"

--- a/src/error.rs
+++ b/src/error.rs
@@ -94,6 +94,9 @@ pub enum Error {
     #[error("Command '{0}' not found.")]
     CommandNotFound(String),
 
+    #[error("Command '{0}' not found. Did you mean: {1}?")]
+    CommandNotFoundWithSuggestions(String, String),
+
     #[error("Version manager error | {0}")]
     VersionManagerError(#[from] VersionManagerError),
 


### PR DESCRIPTION
This PR enhances the `find_task` method of `TaskRunner` by using the `simsearch` crate to suggest similar tasks through fuzzy matching.

Example:

If a task named "build" is defined in `shuru.toml` and the user mistakenly runs `shuru buidl` (a typo), it will suggest something like:

```
Error: Command 'buidl' not found. Did you mean 'build'?
```