### PR TITLE
feat: improve custom error output

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -2,71 +2,77 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum ConfigValidationError {
-    #[error("Command cannot be empty for task: '{0}'.")]
+    #[error("Description: Command cannot be empty for task: '{0}'.")]
     EmptyCommandError(String),
 
-    #[error("Directory cannot be empty for task: '{0}'.")]
+    #[error("Description: Directory cannot be empty for task: '{0}'.")]
     EmptyDirError(String),
 }
 
 #[derive(Debug, Error)]
 pub enum VersionManagerError {
-    #[error("Invalid version: {0}")]
+    #[error("Invalid version\n    Description: {0}")]
     InvalidVersion(String),
 
-    #[error("Unable to find home directory")]
-    UnableHomeDirectory,
+    #[error("Description: Unable to find home directory")]
+    UnableHomeDirectory {},
 
-    #[error("Failed to download version from '{url}' | {source}")]
+    #[error("Description: Failed to download version from '{url}'\n    Technical: {source}")]
     DownloadError {
         url: String,
         #[source]
         source: reqwest::Error,
     },
 
-    #[error("Failed to download {package} from '{url}' | Status: {status}")]
+    #[error(
+        "Description: Failed to download {package} from '{url}'\n    Technical: Status: {status}"
+    )]
     FailedDownloadPackage {
         package: String,
         url: String,
         status: String,
     },
 
-    #[error("Failed to create download file '{file}' | {source}")]
+    #[error("Description: Failed to create download file '{file}'\n    Technical: {source}")]
     FailedCreateFile {
         file: String,
         #[source]
         source: std::io::Error,
     },
 
-    #[error("Failed to write a compressed file '{file}' | {source}")]
+    #[error("Description: Failed to write a compressed file '{file}'\n    Technical: {source}")]
     FailedWriteFile {
         file: String,
         #[source]
         source: reqwest::Error,
     },
 
-    #[error("Failed to remove downloaded archive '{file}' | {source}")]
+    #[error("Description: Failed to remove downloaded archive '{file}'\n    Technical: {source}")]
     FailedDeleteFile {
         file: String,
         #[source]
         source: std::io::Error,
     },
 
-    #[error("Failed to extract archive '{file}' to '{target}' | {error}")]
+    #[error(
+        "Description: Failed to extract archive '{file}' to '{target}'\n    Technical: {error}"
+    )]
     FailedExtractArchive {
         file: String,
         target: String,
         error: String,
     },
 
-    #[error("Failed to run command '{command}' | {source}")]
+    #[error("Description: Failed to run command '{command}'\n    Technical: {source}")]
     FailedRunCommand {
         command: String,
         #[source]
         source: std::io::Error,
     },
 
-    #[error("{package} build command failed | Exit code: {status}{error}")]
+    #[error(
+        "Description: {package} build command failed\n    Technical: Exit code: {status}{error}"
+    )]
     FailedPackageBuildCommand {
         package: String,
         status: i32,
@@ -76,16 +82,16 @@ pub enum VersionManagerError {
 
 #[derive(Debug, Error)]
 pub enum Error {
-    #[error("Configuration loading error: {0}")]
+    #[error("Configuration loading error\n    {0}")]
     ConfigLoadError(String),
 
-    #[error("Configuration validation error: {0}")]
+    #[error("Configuration validation error\n    {0}")]
     ConfigValidationError(#[from] ConfigValidationError),
 
     #[error("Configuration file not found.")]
     ConfigFileNotFound,
 
-    #[error("Command execution error: {0}")]
+    #[error("Command execution error\n    {0}")]
     CommandExecutionError(String),
 
     #[error("No default command found.")]
@@ -97,15 +103,15 @@ pub enum Error {
     #[error("Command '{0}' not found. Did you mean: {1}?")]
     CommandNotFoundWithSuggestions(String, String),
 
-    #[error("Version manager error | {0}")]
+    #[error("Version manager error\n    {0}")]
     VersionManagerError(#[from] VersionManagerError),
 
-    #[error("IO error: {0}")]
+    #[error("IO error\n    Technical: {0}")]
     IoError(#[from] std::io::Error),
 
     #[error("Unable to find home directory.")]
     HomeDirectoryNotFound,
 
-    #[error("Failed to clear cache directory at '{0}': {1}")]
+    #[error("Failed to clear cache directory at '{0}'\n    Technical: {1}")]
     CacheClearError(String, #[source] std::io::Error),
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,11 +33,18 @@ struct Cli {
 fn load_config() -> Result<Config, Error> {
     let config_str = std::fs::read_to_string("shuru.toml").map_err(|e| match e.kind() {
         std::io::ErrorKind::NotFound => Error::ConfigFileNotFound,
-        _ => Error::ConfigLoadError(format!("Unable to read config file: {}", e)),
+        _ => Error::ConfigLoadError(format!(
+            "Description: Unable to read config file\n    Technical: {}",
+            e
+        )),
     })?;
 
-    let mut config: Config = toml::from_str(&config_str)
-        .map_err(|e| Error::ConfigLoadError(format!("Invalid config file format: {}", e)))?;
+    let mut config: Config = toml::from_str(&config_str).map_err(|e| {
+        Error::ConfigLoadError(format!(
+            "Description: Invalid config file format\n    Technical: {}",
+            e
+        ))
+    })?;
 
     update_versions_from_files(&mut config);
 

--- a/src/tools/task_runner/runner.rs
+++ b/src/tools/task_runner/runner.rs
@@ -76,7 +76,10 @@ impl TaskRunner {
 
     fn resolve_work_directory(&self, task: &TaskConfig) -> Result<PathBuf, Error> {
         let current_dir = std::env::current_dir().map_err(|e| {
-            Error::CommandExecutionError(format!("Failed to get current directory: {}", e))
+            Error::CommandExecutionError(format!(
+                "Description: Failed to get current directory: {}",
+                e
+            ))
         })?;
 
         if let Some(dir) = &task.dir {
@@ -95,14 +98,14 @@ impl TaskRunner {
     ) -> Result<(), Error> {
         if !resolved_dir.exists() {
             return Err(Error::CommandExecutionError(format!(
-                "Specified directory does not exist: '{}'",
+                "Description: Specified directory does not exist: '{}'",
                 resolved_dir.display()
             )));
         }
 
         let canonical_dir = std::fs::canonicalize(resolved_dir).map_err(|e| {
             Error::CommandExecutionError(format!(
-                "Failed to canonicalize directory '{}': {}",
+                "Description: Failed to canonicalize directory '{}': {}",
                 resolved_dir.display(),
                 e
             ))
@@ -110,7 +113,7 @@ impl TaskRunner {
 
         if !canonical_dir.starts_with(current_dir) {
             return Err(Error::CommandExecutionError(format!(
-                "Invalid directory '{}'. Cannot navigate outside of the current directory.",
+                "Description: Invalid directory '{}'. Cannot navigate outside of the current directory.",
                 resolved_dir.display()
             )));
         }
@@ -159,9 +162,9 @@ impl TaskRunner {
             .envs(&task.env)
             .arg(&full_command);
 
-        command
-            .status()
-            .map_err(|e| Error::CommandExecutionError(format!("Failed to execute command: {}", e)))
+        command.status().map_err(|e| {
+            Error::CommandExecutionError(format!("Description: Failed to execute command: {}", e))
+        })
     }
 
     fn build_venv_command(
@@ -171,7 +174,9 @@ impl TaskRunner {
         shell_type: &ShellType,
     ) -> Result<String, Error> {
         let activate_str = activate_path.to_str().ok_or_else(|| {
-            Error::CommandExecutionError("Failed to convert activate path to string".to_string())
+            Error::CommandExecutionError(
+                "Description: Failed to convert activate path to string".to_string(),
+            )
         })?;
 
         self.shell_command_format(shell_type, activate_str, task_command)
@@ -211,7 +216,8 @@ impl TaskRunner {
             }
 
             return Err(Error::CommandExecutionError(
-                "Virtual environment detected but activate script not found".to_string(),
+                "Description: Virtual environment detected but activate script not found"
+                    .to_string(),
             ));
         }
 

--- a/src/tools/version_manager/node_version_manager.rs
+++ b/src/tools/version_manager/node_version_manager.rs
@@ -164,7 +164,7 @@ impl VersionValidator for NodeVersionManager {
     fn validate_version(version: &str) -> Result<(), VersionManagerError> {
         let version = version.strip_prefix('v').ok_or_else(|| {
             VersionManagerError::InvalidVersion(format!(
-                "Node version must start with 'v'. Provided: {}. Hint: Use the format vX.Y.Z (e.g., v14.17.0).",
+                "Node version must start with 'v'. Provided: {}\n    Hint: Use the format vX.Y.Z (e.g., v14.17.0).",
                 version
             ))
         })?;
@@ -179,7 +179,7 @@ impl VersionValidator for NodeVersionManager {
             };
 
             return Err(VersionManagerError::InvalidVersion(format!(
-                "Invalid Node version format: {}. Hint: {}",
+                "Invalid Node version format: {}\n    Hint: {}",
                 version, hint
             )));
         }

--- a/src/tools/version_manager/python_version_manager.rs
+++ b/src/tools/version_manager/python_version_manager.rs
@@ -248,7 +248,7 @@ impl PythonVersionManager {
                 return Err(VersionManagerError::FailedPackageBuildCommand {
                     package: "Python".to_string(),
                     status: output.status.code().unwrap(),
-                    error: format!(" > {}", error_message),
+                    error: format!("\n    Technical: {}", error_message),
                 });
             }
         }
@@ -275,7 +275,7 @@ impl VersionValidator for PythonVersionManager {
 
         if !parts.iter().all(|part| part.chars().all(char::is_numeric)) {
             return Err(VersionManagerError::InvalidVersion(format!(
-                "Invalid Python version format: {}. Hint: All parts must be numeric (e.g., 3.10.0).",
+                "Invalid Python version format: {}\n    Hint: All parts must be numeric (e.g., 3.10.0).",
                 version
             )));
         }
@@ -288,7 +288,7 @@ impl VersionValidator for PythonVersionManager {
             };
 
             return Err(VersionManagerError::InvalidVersion(format!(
-                "Invalid Python version format: {}. Hint: {}",
+                "Invalid Python version format: {}\n    Hint: {}",
                 version, hint
             )));
         }

--- a/src/util.rs
+++ b/src/util.rs
@@ -50,12 +50,19 @@ pub fn get_architecture() -> String {
 }
 
 pub fn extract_tar_gz<P: AsRef<Path>>(tar_gz_path: P, dest_dir: P) -> Result<(), Error> {
-    let tar_gz = File::open(tar_gz_path)
-        .map_err(|e| Error::CommandExecutionError(format!("Failed to open tar.gz file: {}", e)))?;
+    let tar_gz = File::open(tar_gz_path).map_err(|e| {
+        Error::CommandExecutionError(format!(
+            "Description: Failed to open tar.gz file\n    Technical: {}",
+            e
+        ))
+    })?;
 
     let mut archive = Archive::new(GzDecoder::new(tar_gz));
     archive.unpack(dest_dir).map_err(|e| {
-        Error::CommandExecutionError(format!("Failed to extract tar.gz file: {}", e))
+        Error::CommandExecutionError(format!(
+            "Description: Failed to extract tar.gz file\n    Technical: {}",
+            e
+        ))
     })?;
 
     Ok(())


### PR DESCRIPTION
This PR improves upon custom error messages as discussed in #29 and closes #30.

There were two errors I had difficulty testing: `UnableHomeDirectory` and `HomeDirectoryNotFound`. In both cases I reformatted the strings, but other errors were either triggered first (i.e. permissions) or I was unable to trick Rust into believing that the users home did not exist (i.e. `HOME="IdontExist" cargo run` just created "IdontExist" in the project root). Further testing can be done if needed, however I may need guidance.

Output:
```
Error: Configuration loading error
    Description: Invalid config file format
    Technical: Unknown version command for key `versions` at line 2 column 1
```