### PR TITLE
feat: add version command to simple Python app example

### DIFF
--- a/examples/simple-python-app/shuru.toml
+++ b/examples/simple-python-app/shuru.toml
@@ -5,6 +5,9 @@ python = "3.10.2"
 name = "setup"
 command = "pip3 install -r requirements.txt"
 
+[tasks.version]
+command = "python --version"
+
 [tasks.run]
 command = "python app.py"
 default = true


### PR DESCRIPTION
This PR closes #36 and adds the version command to `examples/simple-python-app/shuru.toml`.